### PR TITLE
Add EnigmAgent to Tier 2 Security & Quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ For cybersecurity, code quality, and vulnerability management.
 4. Snyk → Dependency auditing
 
 ---
+| **EnigmAgent** | - | ⭐⭐⭐⭐⭐ | AI credential vault — `{{PLACEHOLDER}}` resolution | [GitHub](https://github.com/Agnuxo1/EnigmAgent) |
 
 ## Tier 3: Database & Infrastructure
 


### PR DESCRIPTION
Adds EnigmAgent to the Tier 2 Security & Quality section.

**EnigmAgent** — AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. Resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in prompts, logs, or LLM context.

npm: `npx enigmagent-mcp` | GitHub: https://github.com/Agnuxo1/EnigmAgent