### PR TITLE
Add prompt-to-asset to AI & ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ For cybersecurity, code quality, and vulnerability management.
 - **Hugging Face** (139 downloads) - ML hub access
 - **Pinecone** (45 downloads) - Vector database
 - **[Roundtable](https://roundtable.now)** - Multi-model AI debates: GPT-4o, Claude, Gemini & 200+ models discuss your question, then a moderator synthesizes the best answer. 13 tools including `consult_council`, `review_code`, `debug_issue`, and `design_architecture`. [GitHub](https://github.com/deadpixel/roundtable-dashboard) | [MCP Server](https://mcp.roundtable.now/mcp)
+- **[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset)** - MCP server routing image generation prompts across 30+ models (DALL-E, Flux, Stable Diffusion, Midjourney, and more) via a unified API. `npm install -g prompt-to-asset`.
 
 ### Social Media
 


### PR DESCRIPTION
## Add prompt-to-asset to AI & ML section

[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) is an MCP server that routes image generation prompts across 30+ models — DALL-E, Flux, Stable Diffusion, Midjourney, and more — through a unified API.

Install: `npm install -g prompt-to-asset`

It fits alongside ElevenLabs (audio) and Hugging Face (ML hub) in the AI & ML section as the image generation equivalent.