### PR TITLE
feat: add KubeStellar Console kc-agent to Cloud & Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ For cybersecurity, code quality, and vulnerability management.
 |-----|-----------|----------|
 | **Terraform** | 1,062 | Infrastructure as Code |
 | **Kubernetes** | 1,188 | Container orchestration |
+| **[KubeStellar Console kc-agent](https://github.com/kubestellar/console)** | - | Multi-cluster Kubernetes AI ops |
 | **Cloud Run** | 466 | Serverless deployment |
 | **GKE** | 91 | Google Kubernetes Engine |
 | **Google Cloud** | 22 | GCP integration |


### PR DESCRIPTION
Adds **[KubeStellar Console kc-agent](https://github.com/kubestellar/console)** to the **Cloud & Infrastructure > Kubernetes** section.

kc-agent is the MCP server for KubeStellar Console, a CNCF Sandbox multi-cluster Kubernetes platform. It enables AI tools to manage workloads, query cluster health, and orchestrate operations across multiple edge and cloud Kubernetes clusters.

- GitHub: https://github.com/kubestellar/console
- Demo: https://console.kubestellar.io