### PR TITLE
Add Longbridge MCP to Finance & Trading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ For cybersecurity, code quality, and vulnerability management.
 - **Flutter** (306 downloads) - Mobile development
 - **genkit** (120 downloads) - Full-stack AI apps
 
+### Finance & Trading
+
+- **[Longbridge MCP](https://github.com/longbridge/longbridge-mcp)** - Official Longbridge brokerage MCP — 145 tools for US/HK real-time quotes, options, trading, fundamentals, IPO, alerts, DCA & portfolio. (streamable-http, OAuth 2.1) | [MCP Server](https://openapi.longbridge.com/mcp)
+
 ---
 
 ## Setup Guide


### PR DESCRIPTION
## Add Longbridge MCP to Finance & Trading section

[Longbridge MCP](https://github.com/longbridge/longbridge-mcp) is the official brokerage MCP from Longbridge Securities — 145 tools for US/HK real-time quotes, options, trading, fundamentals, IPO, alerts, DCA & portfolio management.

It adds a new **Finance & Trading** subsection to Tier 4: Specialized Tools (no such section exists yet).

**Why it belongs:**
- Only licensed brokerage MCP with actual trade execution capability
- 145 tools covering the full investment workflow: quotes → analysis → order placement → portfolio monitoring
- Remote streamable-HTTP endpoint (no local install needed)
- OAuth 2.1 RFC 9728 — enterprise-grade auth

**Quick Start:**
```json
{"mcpServers": {"longbridge": {"url": "https://openapi.longbridge.com/mcp"}}}
```

- GitHub: https://github.com/longbridge/longbridge-mcp
- Registry: com.longbridge/mcp v0.3.2 (Official MCP Registry)