### PR TITLE
feat: add TWZRD Agent Intel to AI & ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ For cybersecurity, code quality, and vulnerability management.
 - **Hugging Face** (139 downloads) - ML hub access
 - **Pinecone** (45 downloads) - Vector database
 - **[Roundtable](https://roundtable.now)** - Multi-model AI debates: GPT-4o, Claude, Gemini & 200+ models discuss your question, then a moderator synthesizes the best answer. 13 tools including `consult_council`, `review_code`, `debug_issue`, and `design_architecture`. [GitHub](https://github.com/deadpixel/roundtable-dashboard) | [MCP Server](https://mcp.roundtable.now/mcp)
+- **[TWZRD Agent Intel](https://intel.twzrd.xyz)** - On-chain trust scoring for AI agents on Solana. Verify agent wallet identity and reputation before autonomous task handoffs or x402 micropayments. Tools: `score_agent`, `preflight_check` (free), `get_trust_receipt` (paid). [MCP Server](https://intel.twzrd.xyz/mcp)
 
 ### Social Media
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **AI & ML** section under Tier 4: Specialized Tools.

**What it does**: On-chain trust scoring for AI agents on Solana. Before an agent makes a payment or receives a delegated task, call `score_agent(wallet)` or `preflight_check(wallet)` (both free) to verify the agent's identity and reputation. `get_trust_receipt(wallet)` issues a cryptographic receipt (paid, via x402 micropayment).

**MCP config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Fits in AI & ML alongside Pinecone (vector DB) and Hugging Face as a core piece of AI agent infrastructure — the trust verification layer.